### PR TITLE
Reimplemented add_config using ngrap node and TensorDescCreators

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/base.hpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/base.hpp
@@ -125,7 +125,8 @@ public:
         try {
             impls.push_back(ILayerImpl::Ptr(new IMPL(ngraphOp)));
         } catch (const details::InferenceEngineException& ex) {
-            return ex.getStatus();
+            strncpy(resp->msg, ex.what(), sizeof(resp->msg) - 1);
+            return ex.getStatus() != OK ? ex.getStatus() : GENERAL_ERROR;
         }
         return OK;
     }

--- a/inference-engine/src/mkldnn_plugin/nodes/gather.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/gather.cpp
@@ -26,16 +26,16 @@ using MKLDNNPlugin::TensorDescCreatorTypes;
 
 class GatherImpl: public ExtLayerBase {
 public:
-    static bool isSupportedParams(const std::shared_ptr<ngraph::Node>& op, std::string& errorMessage) noexcept {
+    static bool isSupportedOperation(const ngraph::Node& op, std::string& errorMessage) noexcept {
         try {
-            auto gatherOp = ngraph::as_type_ptr<ngraph::op::v1::Gather>(op);
+            auto gatherOp = ngraph::as_type<const ngraph::op::v1::Gather>(&op);
             if (!gatherOp) {
                 errorMessage = "Only opset1 Gather operation is supported";
                 return false;
             }
 
             auto axesOp = gatherOp->get_input_node_shared_ptr(GATHER_AXIS);
-            if (!ngraph::as_type_ptr<ngraph::op::Constant>(axesOp)) {
+            if (!ngraph::as_type_ptr<const ngraph::op::Constant>(axesOp)) {
                 errorMessage = "Only Constant operation on 'axis' input is supported";
                 return false;
             }
@@ -51,7 +51,7 @@ public:
             errorPrefix_ = std::string("Layer Gather with name '") + op->get_friendly_name() + "' ";
 
             std::string errorMessage;
-            if (!isSupportedParams(op, errorMessage)) {
+            if (!isSupportedOperation(*op, errorMessage)) {
                 THROW_IE_EXCEPTION_WITH_STATUS(NOT_IMPLEMENTED) << errorMessage;
             }
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_generic_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_generic_node.cpp
@@ -77,7 +77,7 @@ bool MKLDNNGenericNode::created(const MKLDNNExtensionManager::Ptr &extMgr) {
             extFactory = extMgr->CreateExtensionFactory(ngraphOp);
 
             if (!extFactory)
-                THROW_IE_EXCEPTION_WITH_STATUS(NOT_IMPLEMENTED) << "Descriptor for generic primitive doesn't exist";
+                THROW_IE_EXCEPTION_WITH_STATUS(NOT_IMPLEMENTED);
 
             std::vector<InferenceEngine::ILayerImpl::Ptr> impls_no_exec;
             InferenceEngine::ResponseDesc resp;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reference_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reference_node.cpp
@@ -12,8 +12,9 @@ using namespace MKLDNNPlugin;
 using namespace InferenceEngine;
 using namespace InferenceEngine::details;
 
-MKLDNNReferenceNode::MKLDNNReferenceNode(const std::shared_ptr<ngraph::Node>& op, const mkldnn::engine& eng, MKLDNNWeightsSharing::Ptr &cache) :
-        MKLDNNNode(op, eng, cache), ngraphOp(op) {
+MKLDNNReferenceNode::MKLDNNReferenceNode(const std::shared_ptr<ngraph::Node>& op, const mkldnn::engine& eng, MKLDNNWeightsSharing::Ptr &cache,
+                                         const std::string& errorMessage) :
+        MKLDNNNode(op, eng, cache), ngraphOp(op), additionalErrorMessage(errorMessage) {
     setType(Reference);
 }
 
@@ -67,12 +68,17 @@ void MKLDNNReferenceNode::execute(mkldnn::stream strm) {
     }
 
     if (!ngraphOp->evaluate(outputs, inputs)) {
-        THROW_IE_EXCEPTION_WITH_STATUS(NOT_IMPLEMENTED)
-            << "Cannot find reference implementation for node " << ngraphOp->get_type_name() << " with name '" << ngraphOp->get_friendly_name() << "'.";
+        std::string errorDetails = "Unsupported operation of type: " + std::string(ngraphOp->get_type_name()) +
+                                   " name: " + std::string(ngraphOp->get_friendly_name());
+        errorDetails += "\nDetails: \n";
+        if (!additionalErrorMessage.empty()) {
+            errorDetails += additionalErrorMessage + "\n";
+        }
+        errorDetails += "Cannot fallback on ngraph reference implementation (Ngraph::Node::evaluate() is not implemented)";
+        THROW_IE_EXCEPTION_WITH_STATUS(NOT_IMPLEMENTED) << errorDetails;
     }
 }
 
 bool MKLDNNReferenceNode::created() const {
     return getType() == Reference;
 }
-REG_MKLDNN_PRIM_FOR(MKLDNNReferenceNode, Reference);

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reference_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reference_node.h
@@ -12,7 +12,7 @@ namespace MKLDNNPlugin {
 
 class MKLDNNReferenceNode : public MKLDNNNode {
 public:
-    MKLDNNReferenceNode(const std::shared_ptr<ngraph::Node>& op, const mkldnn::engine& eng, MKLDNNWeightsSharing::Ptr &cache);
+    MKLDNNReferenceNode(const std::shared_ptr<ngraph::Node>& op, const mkldnn::engine& eng, MKLDNNWeightsSharing::Ptr &cache, const std::string& errorMessage);
     ~MKLDNNReferenceNode() override = default;
 
     void getSupportedDescriptors() override;
@@ -23,6 +23,7 @@ public:
 
 private:
     const std::shared_ptr<ngraph::Node> ngraphOp;
+    const std::string additionalErrorMessage;
 };
 
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/utils/general_utils.h
+++ b/inference-engine/src/mkldnn_plugin/utils/general_utils.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cassert>
+#include <inference_engine.hpp>
 
 namespace MKLDNNPlugin {
 
@@ -37,6 +38,22 @@ constexpr bool everyone_is(T val, P item, Args... item_others) {
 
 constexpr inline bool implication(bool cause, bool cond) {
     return !cause || !!cond;
+}
+
+inline std::string getExceptionDescWithoutStatus(const InferenceEngine::details::InferenceEngineException& ex) noexcept {
+    std::string desc = ex.what();
+    if (ex.getStatus() != 0) {
+        size_t pos = desc.find("]");
+        if (pos != std::string::npos) {
+            if (desc.size() == pos + 1) {
+                desc.erase(0, pos + 1);
+            } else {
+                desc.erase(0, pos + 2);
+            }
+        }
+    }
+
+    return desc;
 }
 
 

--- a/inference-engine/src/mkldnn_plugin/utils/general_utils.h
+++ b/inference-engine/src/mkldnn_plugin/utils/general_utils.h
@@ -40,7 +40,7 @@ constexpr inline bool implication(bool cause, bool cond) {
     return !cause || !!cond;
 }
 
-inline std::string getExceptionDescWithoutStatus(const InferenceEngine::details::InferenceEngineException& ex) noexcept {
+inline std::string getExceptionDescWithoutStatus(const InferenceEngine::details::InferenceEngineException& ex) {
     std::string desc = ex.what();
     if (ex.getStatus() != 0) {
         size_t pos = desc.find("]");


### PR DESCRIPTION
Major changes:

- `add_conig` reimplemented via `TensorDescCreator`: should significantly simplify nodes configuration process.
- Introduced `isSupportedParams()` method that is intended to encapsulate all limitations about unsupported params by CPU implementation. This routine should be also used in callbacks during decomposition of ngraph operations (e.g. should replace `MKLDNNMVNNode::checkAxesSuitability`)
- Properly propagate errorMessages about unsupported params. Now if operation is not supported by the plug-in and we cannot execute it via ngraph reference implementation exception will look like:

>[NOT_IMPLEMENTED] Unsupported operation of type: Gather name: Gather_4121
Details:
Only Constant operation on 'axis' input is supported
Cannot fallback on ngraph reference implementation (Ngraph::Node::evaluate() is not implemented)
